### PR TITLE
feat: adopt CNTUG design system

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -33,6 +33,10 @@ const config = {
     locales: ['zh-TW'],
   },
 
+  markdown: {
+    mermaid: true,
+  },
+
   presets: [
     [
       'classic',
@@ -58,6 +62,8 @@ const config = {
       }),
     ],
   ],
+
+  themes: ['@docusaurus/theme-mermaid'],
 
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@algolia/client-search": "^4.23.2",
     "@docusaurus/core": "^3.2.0",
     "@docusaurus/preset-classic": "^3.2.0",
+    "@docusaurus/theme-mermaid": "3.2.0",
     "@mdx-js/react": "^3.0.1",
     "@types/react": "^18.2.73",
     "clsx": "^2.0.0",

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -9,3 +9,11 @@
   height: 200px;
   width: 200px;
 }
+
+.buttons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: var(--space-3, 0.75rem);
+}

--- a/src/css/README.md
+++ b/src/css/README.md
@@ -1,0 +1,168 @@
+# CNTUG Design System for Docusaurus
+
+Brand-aligned theming for any CNTUG (Cloud Native Taiwan User Group)
+Docusaurus site. Built on the official CNCF brand palette with
+Traditional-Chinese-first typography.
+
+This implementation is what's currently shipping on `docs.cloudnative.tw`
+(the Infra Labs documentation). It is designed to be copied unchanged
+into the main CNTUG website (also Docusaurus) and any future Docusaurus
+projects under the org.
+
+---
+
+## Files
+
+| File | Role | Portable? |
+|---|---|---|
+| `cntug-tokens.css` | Source of truth: CSS custom properties for colors, typography, spacing, radii, shadows, motion. Loads webfonts. Defines light + dark theme variables. | Yes — drop into any project (React, plain HTML, another framework). No element-level rules. |
+| `cntug-infima.css` | Bridge that maps the tokens above onto Infima's `--ifm-*` variables. This is what makes Docusaurus's built-in components (navbar, sidebar, footer, code blocks, admonitions) pick up the brand. | Docusaurus only. |
+| `custom.css` | Docusaurus entry point. Imports the two files above; site-specific tweaks go below the imports. | Per-site. |
+
+---
+
+## Install on a new Docusaurus site
+
+1. **Copy the two portable files** into the new site:
+
+   ```
+   src/css/cntug-tokens.css
+   src/css/cntug-infima.css
+   ```
+
+2. **Replace `src/css/custom.css`** (Docusaurus references this from
+   `docusaurus.config.js`) with:
+
+   ```css
+   @import "./cntug-tokens.css";
+   @import "./cntug-infima.css";
+   /* site-specific overrides here */
+   ```
+
+3. **Verify `docusaurus.config.js`** points at `custom.css`:
+
+   ```js
+   theme: {
+     customCss: require.resolve('./src/css/custom.css'),
+   }
+   ```
+
+4. **Restart the dev server.** The navbar primary, links, code blocks,
+   admonition tints, and dark-mode surfaces will all shift to CNCF blue
+   on Clarity City + Noto Sans TC.
+
+That's it — no plugins, no Docusaurus theme swizzle, no JS.
+
+---
+
+## What gets rebranded
+
+The bridge maps tokens onto these Infima variables:
+
+- **Primary scale** — `--ifm-color-primary*` → CNCF Blue (`#0086FF`),
+  desaturated to `#4DA8FF` in dark mode (Apple HIG: vibrant brand
+  colors should not "buzz" against dark surfaces).
+- **Type stack** — `--ifm-font-family-base`, `--ifm-heading-font-family`,
+  `--ifm-font-family-monospace`. Latin glyphs render in **Clarity City**
+  (CNCF's official typeface), Traditional Chinese in **Noto Sans TC**,
+  code in **JetBrains Mono**. Browsers select per glyph automatically.
+- **Surfaces** — page background, navbar, footer, card surfaces.
+  Dark mode uses layered grays (`#1C1C1E` / `#232326` / `#2C2C2E`) per
+  Apple HIG, not pure black.
+- **Foregrounds** — primary / secondary content. Dark mode uses iOS
+  label tiers (92% / 62% / 40%) instead of pure white.
+- **Borders & emphasis** — the full neutral scale, plus a brand
+  border for active/focused state.
+- **Code** — inline code on `--bg-muted`; block code on near-black
+  with CNCF turquoise text (the "kubectl voice" of the brand).
+- **Admonitions** — info/success/warning/danger inherit semantic
+  status tokens.
+- **Footer** — flipped to CNCF Black, turquoise headings.
+- **Focus ring** — `0 0 0 3px rgba(0, 134, 255, 0.35)`, brand-blue,
+  always visible.
+
+---
+
+## Brand rules to remember
+
+These are the constraints from the CNTUG design system. Honor them
+when adding components or pages:
+
+- **Single accent.** CNCF Blue (`#0086FF`) is the only CTA color.
+  CNCF Turquoise (`#93EAFF`) is the only soft accent. CNCF Pink
+  (`#D62293`) is reserved for emphasis tags ("New", "CFP open").
+  No purple/blue gradients ever.
+- **Bilingual default.** Most surfaces show **Traditional Chinese
+  primary, English secondary** (or English-first technical content
+  with zh-TW alongside).
+- **Type cases.** Sentence case for headings ("Upcoming meetups",
+  not "Upcoming Meetups"). Project names keep canonical casing
+  (Kubernetes, kubectl, Helm, etcd, Prometheus, Envoy, OpenStack).
+- **Backgrounds.** Predominantly white in light, layered grays in
+  dark. No mesh gradients, no abstract blobs, no left-border
+  accent stripes on cards.
+- **Motion.** 120/180/320ms with `cubic-bezier(.2,0,0,1)`. Fades and
+  4px translates only. No bouncy springs, no parallax.
+- **Corner radii.** `4 / 8 / 12 / 16 / 999`. Default `8`. Pills are
+  reserved for tags and avatars.
+- **Icons.** Lucide via CDN at 1.5px stroke, 24px default
+  (`https://unpkg.com/lucide-static@0.469.0/icons/<name>.svg`).
+  Pin the version. CNCF project marks come from
+  <https://github.com/cncf/artwork> — never redraw them by hand.
+- **Emoji.** Sparingly, only as informational glyphs (📍 venue,
+  🗓 date, 🎤 CFP). Never as bullet decoration or in nav.
+
+---
+
+## Using tokens in custom components
+
+All variables are global, so a swizzled or custom React component can
+reference them directly:
+
+```css
+.my-card {
+  background: var(--bg-subtle);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--dur-base) var(--ease-standard);
+}
+.my-card:hover {
+  box-shadow: var(--shadow-md);
+  border-color: var(--border-brand);
+}
+```
+
+The tokens automatically swap when `[data-theme="dark"]` flips, so you
+don't write parallel dark-mode styles for surface/foreground/border
+choices — only for cases where the design intentionally diverges.
+
+---
+
+## Updating the system
+
+The token file is intentionally a **near-verbatim copy** of the
+upstream design package's `colors_and_type.css` (with element-level
+rules stripped so it doesn't fight Infima). When the upstream design
+system changes, re-sync `cntug-tokens.css` first, then revisit
+`cntug-infima.css` only if a new token category was introduced.
+
+Upstream reference: CNTUG Design System bundle (Claude Design export,
+`cntug-design-system/project/`).
+
+---
+
+## Caveats
+
+- **Webfonts load from CDN** (jsdelivr + Google Fonts). Build-time
+  network is not required, but first paint on the live site will
+  briefly fall back to system fonts. Acceptable for documentation;
+  self-host the woff2 files if a fully offline build is needed.
+- **Clarity City via `@import`.** The CDN URL pulls the Clarity UI
+  package; the `@font-face` blocks below it pin individual woff2
+  weights so the family resolves even if the umbrella CSS fails.
+- **Lucide icons.** Pin the version (`@0.469.0`) when introducing
+  new icon usages — the unpinned URL has had 404s on individual icons
+  in the past.

--- a/src/css/cntug-infima.css
+++ b/src/css/cntug-infima.css
@@ -1,0 +1,192 @@
+/* ============================================================
+   CNTUG → Infima bridge
+   Maps the CNTUG design tokens (`cntug-tokens.css`) onto the
+   Infima CSS variables Docusaurus uses, so the existing theme
+   (navbar, sidebar, footer, buttons, code blocks, admonitions)
+   adopts the CNCF brand without per-component overrides.
+
+   Drop this file into any Docusaurus site after `cntug-tokens.css`
+   and it will rebrand the theme.
+   ============================================================ */
+
+:root {
+  /* ---- Primary (CNCF Blue scale) ---- */
+  --ifm-color-primary:         var(--blue-500);
+  --ifm-color-primary-dark:    var(--blue-600);
+  --ifm-color-primary-darker:  var(--blue-700);
+  --ifm-color-primary-darkest: var(--blue-800);
+  --ifm-color-primary-light:   var(--blue-400);
+  --ifm-color-primary-lighter: var(--blue-300);
+  --ifm-color-primary-lightest: var(--blue-200);
+
+  /* ---- Type ---- */
+  --ifm-font-family-base:      var(--font-sans);
+  --ifm-heading-font-family:   var(--font-display);
+  --ifm-font-family-monospace: var(--font-mono);
+  --ifm-heading-font-weight:   var(--fw-bold);
+  --ifm-font-weight-bold:      var(--fw-bold);
+  --ifm-font-weight-semibold:  var(--fw-semibold);
+  --ifm-heading-line-height:   var(--lh-snug);
+
+  /* ---- Surfaces & content ---- */
+  --ifm-background-color:         var(--bg);
+  --ifm-background-surface-color: var(--bg);
+  --ifm-color-content:            var(--fg);
+  --ifm-color-content-secondary:  var(--fg-muted);
+
+  /* ---- Borders / emphasis greys ---- */
+  --ifm-color-emphasis-0:   var(--neutral-0);
+  --ifm-color-emphasis-100: var(--neutral-50);
+  --ifm-color-emphasis-200: var(--neutral-100);
+  --ifm-color-emphasis-300: var(--neutral-200);
+  --ifm-color-emphasis-400: var(--neutral-300);
+  --ifm-color-emphasis-500: var(--neutral-400);
+  --ifm-color-emphasis-600: var(--neutral-500);
+  --ifm-color-emphasis-700: var(--neutral-600);
+  --ifm-color-emphasis-800: var(--neutral-700);
+  --ifm-color-emphasis-900: var(--neutral-800);
+  --ifm-color-emphasis-1000: var(--neutral-900);
+  --ifm-toc-border-color:   var(--border);
+  --ifm-hr-border-color:    var(--border);
+
+  /* ---- Code ---- */
+  --ifm-code-font-size:    92%;
+  --ifm-code-background:   var(--bg-muted);
+  --ifm-code-padding-vertical:   0.1em;
+  --ifm-code-padding-horizontal: 0.4em;
+  --ifm-code-border-radius:      var(--radius-sm);
+  --ifm-pre-background:    var(--neutral-900);
+  --ifm-pre-color:         var(--cncf-turquoise);
+  --ifm-pre-border-radius: var(--radius-md);
+  --docusaurus-highlighted-code-line-bg: rgba(0, 134, 255, 0.10);
+
+  /* ---- Status (admonitions) ---- */
+  --ifm-color-success:        var(--success);
+  --ifm-color-success-contrast-background: var(--success-soft);
+  --ifm-color-warning:        var(--warning);
+  --ifm-color-warning-contrast-background: var(--warning-soft);
+  --ifm-color-danger:         var(--danger);
+  --ifm-color-danger-contrast-background:  var(--danger-soft);
+  /* Info = teal-cyan, intentionally distinct from --cncf-blue so .button--info
+     never collides with .hero--primary or any CNCF-Blue surface. */
+  --ifm-color-info:              var(--info);
+  --ifm-color-info-dark:         #0995AC;
+  --ifm-color-info-darker:       #088CA2;
+  --ifm-color-info-darkest:      #07748B;
+  --ifm-color-info-light:        #1FBDD3;
+  --ifm-color-info-lighter:      #2EC5DA;
+  --ifm-color-info-lightest:     #57D2E2;
+  --ifm-color-info-contrast-background: var(--info-soft);
+  --ifm-color-info-contrast-foreground: #07748B;
+
+  /* ---- Misc ---- */
+  --ifm-hero-background-color: var(--cncf-blue);
+  --ifm-link-color:        var(--fg-brand);
+  --ifm-link-hover-color:  var(--accent-hover);
+  --ifm-navbar-background-color: color-mix(in srgb, var(--bg) 85%, transparent);
+  --ifm-navbar-shadow:           0 1px 0 var(--border);
+  --ifm-footer-background-color: var(--cncf-black);
+  --ifm-footer-color:            var(--cncf-white);
+  --ifm-footer-link-color:       var(--neutral-300);
+  --ifm-footer-title-color:      var(--cncf-turquoise);
+
+  /* ---- Container radii ---- */
+  --ifm-button-border-radius: var(--radius-md);
+  --ifm-card-border-radius:   var(--radius-lg);
+  --ifm-global-radius:        var(--radius-md);
+  --ifm-alert-border-radius:  var(--radius-md);
+}
+
+[data-theme='dark'] {
+  /* Primary shifts to the desaturated CNCF Blue from cntug-tokens.css */
+  --ifm-color-primary:          #4DA8FF;
+  --ifm-color-primary-dark:     #2E97FF;
+  --ifm-color-primary-darker:   #1F8FFF;
+  --ifm-color-primary-darkest:  #0086FF;
+  --ifm-color-primary-light:    #6FB8FF;
+  --ifm-color-primary-lighter:  #80C2FF;
+  --ifm-color-primary-lightest: #A8D5FF;
+
+  /* Info: teal — distinct from hero (#4DA8FF) and --cncf-blue on dark surfaces */
+  --ifm-color-info:              #4DD3E8;
+  --ifm-color-info-dark:         #2EC5DA;
+  --ifm-color-info-darker:       #1FBDD3;
+  --ifm-color-info-darkest:      #0AA8C0;
+  --ifm-color-info-light:        #6FDBED;
+  --ifm-color-info-lighter:      #80E0F0;
+  --ifm-color-info-lightest:     #A8EBF5;
+
+  --ifm-background-color:         var(--bg);
+  --ifm-background-surface-color: var(--bg-subtle);
+  --ifm-color-content:            var(--fg);
+  --ifm-color-content-secondary:  var(--fg-muted);
+
+  --ifm-toc-border-color: var(--border);
+  --ifm-hr-border-color:  var(--border);
+
+  --ifm-code-background:  var(--bg-muted);
+  --ifm-pre-background:   #0A0A0A;
+  --ifm-pre-color:        var(--cncf-turquoise);
+
+  --ifm-link-color:       var(--fg-brand);
+  --ifm-link-hover-color: var(--accent-hover);
+
+  --docusaurus-highlighted-code-line-bg: rgba(77, 168, 255, 0.18);
+}
+
+/* ============================================================
+   Targeted refinements that Infima vars don't reach
+   ============================================================ */
+
+/* Brand-blue focus ring everywhere */
+:where(a, button, [role='button'], input, select, textarea, summary):focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+  border-radius: var(--radius-sm);
+}
+
+/* Eyebrow utility — CNCF-blue tracked-out small caps (use on intro labels) */
+.eyebrow {
+  display: inline-block;
+  font-size: var(--fs-12);
+  font-weight: var(--fw-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  color: var(--fg-brand);
+}
+
+/* Display headings get the brand letter-spacing tightening */
+.markdown h1,
+.markdown h2 { letter-spacing: var(--tracking-tight); }
+
+/* Body prose width follows the design system's reading rhythm */
+.markdown { text-wrap: pretty; }
+
+/* Sponsor / emphasis tag (used on community pages) */
+.button--sponsor {
+  --ifm-color-primary:         var(--cncf-pink);
+  --ifm-color-primary-dark:    #BF1F84;
+  --ifm-color-primary-darker:  #B41D7D;
+  --ifm-color-primary-darkest: #941867;
+  --ifm-color-primary-light:   #DD3FA1;
+  --ifm-color-primary-lighter: #E150A9;
+  --ifm-color-primary-lightest: #E978BC;
+}
+[data-theme='dark'] .button--sponsor {
+  --ifm-color-primary:          var(--cncf-pink);
+  --ifm-color-primary-dark:     #ED85C2;
+  --ifm-color-primary-darker:   #F19BCD;
+  --ifm-color-primary-darkest:  #F7C2DF;
+  --ifm-color-primary-light:    #ED85C2;
+  --ifm-color-primary-lighter:  #F19BCD;
+  --ifm-color-primary-lightest: #F7C2DF;
+}
+
+/* Docusaurus derives .hero--primary background from --ifm-color-primary,
+   not --ifm-hero-background-color (which is not a real Infima variable).
+   In dark mode --ifm-color-primary is #4DA8FF which makes the hero look
+   washed out. Pin it directly to blue-800 instead. */
+[data-theme='dark'] .hero--primary {
+  background-color: #003566 !important;
+  color: #FFFFFF;
+}

--- a/src/css/cntug-tokens.css
+++ b/src/css/cntug-tokens.css
@@ -1,0 +1,300 @@
+/* ============================================================
+   CNTUG Design System — design tokens
+   Cloud Native Taiwan User Group
+   Built on the official CNCF brand palette.
+
+   Source of truth: colors, type, spacing, radii, shadows, motion.
+   This file defines CSS custom properties only — no element rules —
+   so it can be dropped into any project (Docusaurus, plain HTML,
+   React, etc.) without conflicting with the host stylesheet.
+
+   Pair with `cntug-infima.css` when used inside Docusaurus.
+   See `src/css/README.md` for reproduction instructions.
+   ============================================================ */
+
+/* ---------- Webfonts ----------
+   Clarity City — CNCF's official typeface (VMware Clarity Design System, OFL).
+   @font-face blocks below load only the font files; no Clarity component CSS is imported. */
+/* Noto Sans TC — Traditional Chinese (primary language for CNTUG). */
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700;900&display=swap");
+/* JetBrains Mono — code, terminal, kubectl examples. */
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap");
+
+@font-face {
+  font-family: "Clarity City";
+  font-weight: 400;
+  font-style: normal;
+  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/Regular/ClarityCityRegular.woff2") format("woff2");
+  font-display: swap;
+}
+@font-face {
+  font-family: "Clarity City";
+  font-weight: 500;
+  font-style: normal;
+  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/Medium/ClarityCityMedium.woff2") format("woff2");
+  font-display: swap;
+}
+@font-face {
+  font-family: "Clarity City";
+  font-weight: 600;
+  font-style: normal;
+  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/SemiBold/ClarityCitySemiBold.woff2") format("woff2");
+  font-display: swap;
+}
+@font-face {
+  font-family: "Clarity City";
+  font-weight: 700;
+  font-style: normal;
+  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/Bold/ClarityCityBold.woff2") format("woff2");
+  font-display: swap;
+}
+@font-face {
+  font-family: "Clarity City";
+  font-weight: 800;
+  font-style: normal;
+  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/ExtraBold/ClarityCityExtraBold.woff2") format("woff2");
+  font-display: swap;
+}
+
+:root {
+  /* ============================================================
+     COLORS — Official CNCF palette
+     ============================================================ */
+
+  /* Primary brand */
+  --cncf-blue:      #0086FF;  /* CNCF Blue       — pantone 285C */
+  --cncf-black:     #000000;  /* CNCF Black      — pantone Black C */
+
+  /* Secondary */
+  --cncf-turquoise: #93EAFF;  /* CNCF Turquoise  — pantone 2995C */
+  --cncf-pink:      #D62293;  /* CNCF Pink       — pantone 213C */
+  --cncf-stone:     #E5E5E5;  /* CNCF Stone      — warm grey 1C */
+  --cncf-white:     #FFFFFF;  /* CNCF Cloud White */
+
+  /* Tints / shades extending CNCF Blue */
+  --blue-50:   #E6F3FF;
+  --blue-100:  #CCE7FF;
+  --blue-200:  #99CFFF;
+  --blue-300:  #66B7FF;
+  --blue-400:  #339FFF;
+  --blue-500:  #0086FF;
+  --blue-600:  #006BCC;
+  --blue-700:  #005099;
+  --blue-800:  #003566;
+  --blue-900:  #001A33;
+
+  /* Neutrals (warm, derived from CNCF Stone) */
+  --neutral-0:    #FFFFFF;
+  --neutral-50:   #FAFAFA;
+  --neutral-100:  #F4F4F5;
+  --neutral-200:  #E5E5E5;
+  --neutral-300:  #D4D4D4;
+  --neutral-400:  #A3A3A3;
+  --neutral-500:  #737373;
+  --neutral-600:  #525252;
+  --neutral-700:  #404040;
+  --neutral-800:  #262626;
+  --neutral-900:  #0A0A0A;
+
+  /* Semantic — surfaces */
+  --bg:           var(--neutral-0);
+  --bg-subtle:    var(--neutral-50);
+  --bg-muted:     var(--neutral-100);
+  --bg-inverse:   var(--cncf-black);
+
+  /* Semantic — foregrounds */
+  --fg:           var(--neutral-900);
+  --fg-muted:     var(--neutral-600);
+  --fg-subtle:    var(--neutral-500);
+  --fg-inverse:   var(--cncf-white);
+  --fg-brand:     var(--cncf-blue);
+
+  /* Semantic — borders */
+  --border:        var(--neutral-200);
+  --border-strong: var(--neutral-300);
+  --border-brand:  var(--cncf-blue);
+
+  /* Semantic — accents */
+  --accent:        var(--cncf-blue);
+  --accent-hover:  var(--blue-600);
+  --accent-press:  var(--blue-700);
+  --accent-soft:   var(--blue-50);
+
+  /* Status */
+  --success:       #16A34A;
+  --success-soft:  #DCFCE7;
+  --warning:       #EAB308;
+  --warning-soft:  #FEF9C3;
+  --danger:        #DC2626;
+  --danger-soft:   #FEE2E2;
+  /* Info is a STATUS hue, intentionally distinct from --cncf-blue (the CTA / brand
+     accent) so that Infima's .button--info never collides with .hero--primary. */
+  --info:          #0AA8C0;
+  --info-soft:     #E0F7FB;
+
+  /* Shadows — tinted toward CNCF deep blue ("blueprint", not grey) */
+  --shadow-xs: 0 1px 2px rgba(0, 26, 51, 0.06);
+  --shadow-sm: 0 2px 4px rgba(0, 26, 51, 0.06), 0 1px 2px rgba(0, 26, 51, 0.04);
+  --shadow-md: 0 4px 12px rgba(0, 26, 51, 0.08), 0 2px 4px rgba(0, 26, 51, 0.04);
+  --shadow-lg: 0 12px 32px rgba(0, 26, 51, 0.10), 0 4px 8px rgba(0, 26, 51, 0.04);
+  --shadow-xl: 0 24px 48px rgba(0, 26, 51, 0.14);
+  --shadow-focus: 0 0 0 3px rgba(0, 134, 255, 0.35);
+
+  /* ============================================================
+     TYPOGRAPHY
+     Clarity City wins on Latin glyphs (CNCF brand);
+     Noto Sans TC handles Traditional Chinese.
+     ============================================================ */
+  --font-sans:    "Clarity City", "Noto Sans TC", -apple-system, BlinkMacSystemFont, "PingFang TC", "Microsoft JhengHei", system-ui, sans-serif;
+  --font-display: "Clarity City", "Noto Sans TC", -apple-system, system-ui, sans-serif;
+  --font-tc:      "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif;
+  --font-mono:    "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+
+  --fs-12:  0.75rem;
+  --fs-14:  0.875rem;
+  --fs-16:  1rem;
+  --fs-18:  1.125rem;
+  --fs-20:  1.25rem;
+  --fs-24:  1.5rem;
+  --fs-30:  1.875rem;
+  --fs-36:  2.25rem;
+  --fs-48:  3rem;
+  --fs-60:  3.75rem;
+  --fs-72:  4.5rem;
+
+  --lh-tight:   1.1;
+  --lh-snug:    1.25;
+  --lh-normal:  1.5;
+  --lh-relaxed: 1.65;
+
+  --fw-regular:  400;
+  --fw-medium:   500;
+  --fw-semibold: 600;
+  --fw-bold:     700;
+  --fw-black:    800;
+
+  --tracking-tight:  -0.02em;
+  --tracking-normal: 0;
+  --tracking-wide:   0.04em;
+  --tracking-wider:  0.08em;
+
+  /* ============================================================
+     SPACING / RADII / MOTION
+     ============================================================ */
+  --space-0:  0;
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  24px;
+  --space-6:  32px;
+  --space-7:  48px;
+  --space-8:  64px;
+  --space-9:  96px;
+  --space-10: 128px;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-pill: 999px;
+
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --ease-decel:    cubic-bezier(0, 0, 0.2, 1);
+  --ease-accel:    cubic-bezier(0.4, 0, 1, 1);
+  --dur-fast: 120ms;
+  --dur-base: 180ms;
+  --dur-slow: 320ms;
+}
+
+/* ============================================================
+   DARK THEME — Apple HIG-inspired
+   - Layered grays, not pure black (depth via elevation, not contrast).
+   - CNCF Blue lifted to #4DA8FF so it stays legible without buzzing.
+   - Foregrounds use iOS label tiers (90% / 60% / 38%).
+   - Borders are luminance-up, not opacity-down.
+
+   Activated by `[data-theme="dark"]` (Docusaurus convention)
+   or `.theme-dark` (manual opt-in).
+   ============================================================ */
+[data-theme="dark"], .theme-dark {
+  color-scheme: dark;
+
+  --bg:            #1C1C1E;
+  --bg-subtle:     #232326;
+  --bg-muted:      #2C2C2E;
+  --bg-inverse:    #F2F2F7;
+
+  --fg:            rgba(235, 235, 245, 0.92);
+  --fg-muted:      rgba(235, 235, 245, 0.62);
+  --fg-subtle:     rgba(235, 235, 245, 0.40);
+  --fg-inverse:    #1C1C1E;
+  --fg-brand:      #4DA8FF;
+
+  --border:        rgba(235, 235, 245, 0.10);
+  --border-strong: rgba(235, 235, 245, 0.18);
+  --border-brand:  #4DA8FF;
+
+  --cncf-blue:     #4DA8FF;
+  --cncf-turquoise:#9FE9FF;
+  --cncf-pink:     #E96FB7;
+
+  --blue-50:   rgba(77, 168, 255, 0.10);
+  --blue-100:  rgba(77, 168, 255, 0.16);
+  --blue-200:  rgba(77, 168, 255, 0.28);
+  --blue-300:  #6FB8FF;
+  --blue-400:  #4DA8FF;
+  --blue-500:  #4DA8FF;
+  --blue-600:  #6FB8FF;
+  --blue-700:  #9FCBFF;
+  --blue-800:  #CCE2FF;
+  --blue-900:  #E6F0FF;
+
+  --accent:        var(--cncf-blue);
+  --accent-hover:  #6FB8FF;
+  --accent-press:  #9FCBFF;
+  --accent-soft:   rgba(77, 168, 255, 0.14);
+
+  --success:       #4ADE80;
+  --success-soft:  rgba(74, 222, 128, 0.14);
+  --warning:       #FACC15;
+  --warning-soft:  rgba(250, 204, 21, 0.14);
+  --danger:        #F87171;
+  --danger-soft:   rgba(248, 113, 113, 0.14);
+  --info:          #4DD3E8;
+  --info-soft:     rgba(77, 211, 232, 0.14);
+
+  --shadow-xs: 0 1px 2px rgba(0,0,0,0.35);
+  --shadow-sm: 0 2px 4px rgba(0,0,0,0.40), 0 1px 2px rgba(0,0,0,0.30);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.45), 0 2px 4px rgba(0,0,0,0.30);
+  --shadow-lg: 0 12px 32px rgba(0,0,0,0.55), 0 4px 8px rgba(0,0,0,0.30);
+  --shadow-xl: 0 24px 48px rgba(0,0,0,0.60);
+  --shadow-focus: 0 0 0 3px rgba(77, 168, 255, 0.45);
+}
+
+/* Auto dark theme when user prefers it (still overridable via [data-theme=light]) */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+    --bg: #1C1C1E; --bg-subtle: #232326; --bg-muted: #2C2C2E; --bg-inverse: #F2F2F7;
+    --fg: rgba(235,235,245,0.92); --fg-muted: rgba(235,235,245,0.62); --fg-subtle: rgba(235,235,245,0.40); --fg-inverse: #1C1C1E; --fg-brand: #4DA8FF;
+    --border: rgba(235,235,245,0.10); --border-strong: rgba(235,235,245,0.18); --border-brand: #4DA8FF;
+    --cncf-blue: #4DA8FF; --cncf-turquoise: #9FE9FF; --cncf-pink: #E96FB7;
+    --blue-50: rgba(77,168,255,0.10); --blue-100: rgba(77,168,255,0.16); --blue-200: rgba(77,168,255,0.28);
+    --blue-300: #6FB8FF; --blue-400: #4DA8FF; --blue-500: #4DA8FF; --blue-600: #6FB8FF; --blue-700: #9FCBFF; --blue-800: #CCE2FF; --blue-900: #E6F0FF;
+    --accent: #4DA8FF; --accent-hover: #6FB8FF; --accent-press: #9FCBFF; --accent-soft: rgba(77,168,255,0.14);
+    --success:#4ADE80; --success-soft:rgba(74,222,128,0.14);
+    --warning:#FACC15; --warning-soft:rgba(250,204,21,0.14);
+    --danger:#F87171;  --danger-soft:rgba(248,113,113,0.14);
+    --info:#4DD3E8; --info-soft:rgba(77,211,232,0.14);
+    --shadow-xs:0 1px 2px rgba(0,0,0,.35);
+    --shadow-sm:0 2px 4px rgba(0,0,0,.40),0 1px 2px rgba(0,0,0,.30);
+    --shadow-md:0 4px 12px rgba(0,0,0,.45),0 2px 4px rgba(0,0,0,.30);
+    --shadow-lg:0 12px 32px rgba(0,0,0,.55),0 4px 8px rgba(0,0,0,.30);
+    --shadow-xl:0 24px 48px rgba(0,0,0,.60);
+    --shadow-focus:0 0 0 3px rgba(77,168,255,.45);
+  }
+}
+
+::selection { background: var(--cncf-turquoise); color: var(--cncf-black); }
+[data-theme="dark"] ::selection { background: var(--cncf-turquoise); color: var(--cncf-black); }

--- a/src/css/cntug-tokens.css
+++ b/src/css/cntug-tokens.css
@@ -24,35 +24,35 @@
   font-family: "Clarity City";
   font-weight: 400;
   font-style: normal;
-  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/Regular/ClarityCityRegular.woff2") format("woff2");
+  src: url("https://cdn.jsdelivr.net/npm/@clr/city@1.1.0/Webfonts/WOFF2/ClarityCity-Regular.woff2") format("woff2");
   font-display: swap;
 }
 @font-face {
   font-family: "Clarity City";
   font-weight: 500;
   font-style: normal;
-  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/Medium/ClarityCityMedium.woff2") format("woff2");
+  src: url("https://cdn.jsdelivr.net/npm/@clr/city@1.1.0/Webfonts/WOFF2/ClarityCity-Medium.woff2") format("woff2");
   font-display: swap;
 }
 @font-face {
   font-family: "Clarity City";
   font-weight: 600;
   font-style: normal;
-  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/SemiBold/ClarityCitySemiBold.woff2") format("woff2");
+  src: url("https://cdn.jsdelivr.net/npm/@clr/city@1.1.0/Webfonts/WOFF2/ClarityCity-SemiBold.woff2") format("woff2");
   font-display: swap;
 }
 @font-face {
   font-family: "Clarity City";
   font-weight: 700;
   font-style: normal;
-  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/Bold/ClarityCityBold.woff2") format("woff2");
+  src: url("https://cdn.jsdelivr.net/npm/@clr/city@1.1.0/Webfonts/WOFF2/ClarityCity-Bold.woff2") format("woff2");
   font-display: swap;
 }
 @font-face {
   font-family: "Clarity City";
   font-weight: 800;
   font-style: normal;
-  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/ExtraBold/ClarityCityExtraBold.woff2") format("woff2");
+  src: url("https://cdn.jsdelivr.net/npm/@clr/city@1.1.0/Webfonts/WOFF2/ClarityCity-ExtraBold.woff2") format("woff2");
   font-display: swap;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -32,3 +32,20 @@
   --ifm-color-primary-lighter: #ef73bd;
   --ifm-color-primary-lightest: #f49dd1;
 }
+
+/* Mermaid diagrams — colours/fonts come from the swizzled @theme/Mermaid
+   (src/theme/Mermaid). This only handles layout, since the swizzle does not
+   pull in the theme's own container stylesheet. On every
+   @docusaurus/theme-mermaid bump, re-check
+   node_modules/@docusaurus/theme-mermaid/lib/theme/Mermaid/styles.module.css
+   for new rules worth mirroring here. */
+.docusaurus-mermaid-container {
+  max-width: 100%;
+  margin: var(--space-5) 0;
+  text-align: center;
+}
+
+.docusaurus-mermaid-container > svg {
+  max-width: 100%;
+  height: auto;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,36 +1,20 @@
 /**
- * Any CSS included here will be global. The classic template
- * bundles Infima by default. Infima is a CSS framework designed to
- * work well for content-centric websites.
+ * Global styles for the Cloud Native Taiwan User Group Docusaurus site.
+ *
+ * The visual system lives in two portable files:
+ *   - cntug-tokens.css   design tokens (colors, type, spacing, motion)
+ *   - cntug-infima.css   maps tokens onto Docusaurus / Infima variables
+ *
+ * Add site-specific tweaks below those imports. See ./README.md for
+ * how the design system is structured and how to reuse it.
  */
 
-/* You can override the default Infima variables here. */
-:root {
-  --ifm-color-primary: #0086ff;
-  --ifm-color-primary-dark: #0079e6;
-  --ifm-color-primary-darker: #0072d9;
-  --ifm-color-primary-darkest: #005eb3;
-  --ifm-color-primary-light: #1a92ff;
-  --ifm-color-primary-lighter: #2698ff;
-  --ifm-color-primary-lightest: #4daaff;
-  --ifm-code-font-size: 95%;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
-}
+@import "./cntug-tokens.css";
+@import "./cntug-infima.css";
 
-/* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme='dark'] {
-  --ifm-color-primary: #93eaff;
-  --ifm-color-primary-dark: #6be2ff;
-  --ifm-color-primary-darker: #57deff;
-  --ifm-color-primary-darkest: #1ad3ff;
-  --ifm-color-primary-light: #bbf2ff;
-  --ifm-color-primary-lighter: #cff6ff;
-  --ifm-color-primary-lightest: #ffffff;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
-}
-
+/* Site-specific: sponsor CTA uses CNCF Pink (reserved for emphasis). */
 .button--sponsor {
-  --ifm-color-primary: #d03592;
+  --ifm-color-primary: var(--cncf-pink);
   --ifm-color-primary-dark: #bf2c84;
   --ifm-color-primary-darker: #b42a7d;
   --ifm-color-primary-darkest: #942267;

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -20,4 +20,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
+  gap: var(--space-3, 0.75rem);
 }

--- a/src/theme/Mermaid/index.js
+++ b/src/theme/Mermaid/index.js
@@ -1,0 +1,152 @@
+/**
+ * Swizzled @theme/Mermaid — themes every Mermaid diagram on the site with the
+ * CNTUG design system, with correct light/dark palettes.
+ *
+ * WHY A SWIZZLE: @docusaurus/theme-mermaid only accepts ONE static `options`
+ * object (incl. themeVariables) shared across colour modes, so per-mode colours
+ * are impossible from docusaurus.config.js alone. The render hook
+ * (useMermaidRenderResult) does accept a custom `config`, so we build it here
+ * from useColorMode() and feed Mermaid a different palette per mode.
+ *
+ * COLOURS MUST BE CONCRETE HEX. Mermaid derives shades with the khroma colour
+ * library and strips values containing dashes, so CSS `var(--token)` cannot be
+ * used in themeVariables. The hex values below mirror the design tokens in
+ * src/css/cntug-tokens.css (light :root and [data-theme="dark"]). Keep them in
+ * sync if the tokens change. `fontFamily` is NOT colour-processed, so the font
+ * stack (matching --font-sans) is fine there.
+ */
+import React, {useEffect, useMemo, useRef} from 'react';
+import ErrorBoundary from '@docusaurus/ErrorBoundary';
+import {useColorMode, ErrorBoundaryErrorMessageFallback} from '@docusaurus/theme-common';
+import {
+  MermaidContainerClassName,
+  useMermaidRenderResult,
+} from '@docusaurus/theme-mermaid/client';
+
+const FONT =
+  '"Clarity City", "Noto Sans TC", -apple-system, BlinkMacSystemFont, "PingFang TC", "Microsoft JhengHei", system-ui, sans-serif';
+
+// Light palette — mirrors src/css/cntug-tokens.css :root.
+const LIGHT = {
+  background: '#ffffff',
+  // Nodes
+  primaryColor: '#E6F3FF', // --blue-50
+  mainBkg: '#E6F3FF',
+  primaryTextColor: '#001A33', // --blue-900
+  nodeTextColor: '#001A33',
+  primaryBorderColor: '#0086FF', // --cncf-blue
+  nodeBorder: '#0086FF',
+  secondaryColor: '#F4F4F5', // --bg-muted
+  tertiaryColor: '#FAFAFA', // --neutral-50
+  secondaryTextColor: '#0A0A0A',
+  tertiaryTextColor: '#0A0A0A',
+  // Edges / text
+  lineColor: '#737373', // --neutral-500
+  textColor: '#0A0A0A', // --fg
+  titleColor: '#0A0A0A',
+  edgeLabelBackground: '#ffffff',
+  // Subgraphs
+  clusterBkg: '#F4F4F5',
+  clusterBorder: '#D4D4D4', // --border-strong
+  // Sequence diagrams
+  actorBkg: '#E6F3FF',
+  actorBorder: '#0086FF',
+  actorTextColor: '#001A33',
+  actorLineColor: '#737373',
+  signalColor: '#525252', // --neutral-600
+  signalTextColor: '#0A0A0A',
+  labelBoxBkgColor: '#F4F4F5',
+  labelBoxBorderColor: '#D4D4D4',
+  labelTextColor: '#0A0A0A',
+  loopTextColor: '#525252',
+  noteBkgColor: '#E0F7FB', // --info-soft
+  noteTextColor: '#0A0A0A',
+  noteBorderColor: '#0AA8C0', // --info
+  activationBkgColor: '#CCE7FF', // --blue-100
+  activationBorderColor: '#0086FF',
+  sequenceNumberColor: '#ffffff',
+};
+
+// Dark palette — mirrors src/css/cntug-tokens.css [data-theme="dark"].
+const DARK = {
+  background: '#1C1C1E',
+  primaryColor: '#16314F', // dark blue surface
+  mainBkg: '#16314F',
+  primaryTextColor: '#EBEBF5',
+  nodeTextColor: '#EBEBF5',
+  primaryBorderColor: '#4DA8FF', // dark --cncf-blue
+  nodeBorder: '#4DA8FF',
+  secondaryColor: '#2C2C2E', // dark --bg-muted
+  tertiaryColor: '#232326', // dark --bg-subtle
+  secondaryTextColor: '#EBEBF5',
+  tertiaryTextColor: '#EBEBF5',
+  lineColor: '#98989D',
+  textColor: '#EBEBF5',
+  titleColor: '#EBEBF5',
+  edgeLabelBackground: '#1C1C1E',
+  clusterBkg: '#232326',
+  clusterBorder: '#48484A',
+  actorBkg: '#16314F',
+  actorBorder: '#4DA8FF',
+  actorTextColor: '#EBEBF5',
+  actorLineColor: '#98989D',
+  signalColor: '#C7C7CC',
+  signalTextColor: '#EBEBF5',
+  labelBoxBkgColor: '#2C2C2E',
+  labelBoxBorderColor: '#48484A',
+  labelTextColor: '#EBEBF5',
+  loopTextColor: '#C7C7CC',
+  noteBkgColor: '#143A42', // dark info tint
+  noteTextColor: '#EBEBF5',
+  noteBorderColor: '#4DD3E8', // dark --info
+  activationBkgColor: '#22344A',
+  activationBorderColor: '#4DA8FF',
+  sequenceNumberColor: '#1C1C1E',
+};
+
+function MermaidRenderResult({renderResult}) {
+  const ref = useRef(null);
+  useEffect(() => {
+    // Capture the node at effect-setup time (mirrors upstream) so a strict-mode
+    // remount can't hand bindFunctions a different/stale node.
+    const div = ref.current;
+    renderResult.bindFunctions?.(div);
+  }, [renderResult]);
+  return (
+    <div
+      ref={ref}
+      className={MermaidContainerClassName}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{__html: renderResult.svg}}
+    />
+  );
+}
+
+function MermaidRenderer({value}) {
+  const {colorMode} = useColorMode();
+  // Memoise so Mermaid only re-renders when the colour mode actually flips,
+  // not on every parent render.
+  const config = useMemo(
+    () => ({
+      startOnLoad: false,
+      theme: 'base',
+      fontFamily: FONT,
+      themeVariables: colorMode === 'dark' ? DARK : LIGHT,
+    }),
+    [colorMode],
+  );
+  const renderResult = useMermaidRenderResult({text: value, config});
+  if (renderResult === null) {
+    return null;
+  }
+  return <MermaidRenderResult renderResult={renderResult} />;
+}
+
+export default function Mermaid(props) {
+  return (
+    <ErrorBoundary
+      fallback={(params) => <ErrorBoundaryErrorMessageFallback {...params} />}>
+      <MermaidRenderer {...props} />
+    </ErrorBoundary>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1227,6 +1227,11 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
+"@braintree/sanitize-url@^6.0.1":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz#923ca57e173c6b232bbbb07347b1be982f03e783"
+  integrity sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -1585,6 +1590,19 @@
     prism-react-renderer "^2.3.0"
     tslib "^2.6.0"
     utility-types "^3.10.0"
+
+"@docusaurus/theme-mermaid@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-mermaid/-/theme-mermaid-3.2.0.tgz#b6d43b853ccc562a9c0be28e1100dad6324b8a8f"
+  integrity sha512-PvN6K6m3JaM9cr9oSPyba6OlwAiSfBzqQtNqdgPFDjakKuT4kj6JODfExi+HKtWuxayOVRQlRl7zTnWxM4sTVw==
+  dependencies:
+    "@docusaurus/core" "3.2.0"
+    "@docusaurus/module-type-aliases" "3.2.0"
+    "@docusaurus/theme-common" "3.2.0"
+    "@docusaurus/types" "3.2.0"
+    "@docusaurus/utils-validation" "3.2.0"
+    mermaid "^10.4.0"
+    tslib "^2.6.0"
 
 "@docusaurus/theme-search-algolia@3.2.0":
   version "3.2.0"
@@ -2042,6 +2060,23 @@
   dependencies:
     "@types/node" "*"
 
+"@types/d3-scale-chromatic@^3.0.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#dc6d4f9a98376f18ea50bad6c39537f1b5463c39"
+  integrity sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==
+
+"@types/d3-scale@^4.0.3":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.9.tgz#57a2f707242e6fe1de81ad7bfcccaaf606179afb"
+  integrity sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-time@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
+  integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
+
 "@types/debug@^4.0.0":
   version "4.1.12"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"
@@ -2159,6 +2194,13 @@
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
+"@types/mdast@^3.0.0":
+  version "3.0.15"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.15.tgz#49c524a263f30ffa28b71ae282f813ed000ab9f5"
+  integrity sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==
+  dependencies:
+    "@types/unist" "^2"
 
 "@types/mdast@^4.0.0", "@types/mdast@^4.0.2":
   version "4.0.3"
@@ -2322,10 +2364,20 @@
   dependencies:
     "@types/node" "*"
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.2.tgz#6dd61e43ef60b34086287f83683a5c1b2dc53d20"
   integrity sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==
+
+"@types/unist@^2":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.11.tgz#11af57b127e32487774841f7a4e54eab166d03c4"
+  integrity sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==
 
 "@types/unist@^2.0.0":
   version "2.0.10"
@@ -3111,6 +3163,11 @@ comma-separated-tokens@^2.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
   integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
 
+commander@7, commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
 commander@^10.0.0:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
@@ -3125,11 +3182,6 @@ commander@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
-
-commander@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
-  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 commander@^8.3.0:
   version "8.3.0"
@@ -3265,6 +3317,13 @@ core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+cose-base@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cose-base/-/cose-base-1.0.3.tgz#650334b41b869578a543358b80cda7e0abe0a60a"
+  integrity sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==
+  dependencies:
+    layout-base "^1.0.0"
 
 cosmiconfig@^6.0.0:
   version "6.0.0"
@@ -3458,6 +3517,302 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
+cytoscape-cose-bilkent@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz#762fa121df9930ffeb51a495d87917c570ac209b"
+  integrity sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==
+  dependencies:
+    cose-base "^1.0.0"
+
+cytoscape@^3.28.1:
+  version "3.34.0"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.34.0.tgz#5fbe2eb1cf76b070a8ecd5647c35f65aa097c9c6"
+  integrity sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==
+
+"d3-array@1 - 2":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.12.1.tgz#e20b41aafcdffdf5d50928004ececf815a465e81"
+  integrity sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==
+  dependencies:
+    internmap "^1.0.0"
+
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.2.0:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
+  dependencies:
+    internmap "1 - 2"
+
+d3-axis@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
+  integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
+
+d3-brush@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-3.0.0.tgz#6f767c4ed8dcb79de7ede3e1c0f89e63ef64d31c"
+  integrity sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "3"
+    d3-transition "3"
+
+d3-chord@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-3.0.1.tgz#d156d61f485fce8327e6abf339cb41d8cbba6966"
+  integrity sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==
+  dependencies:
+    d3-path "1 - 3"
+
+"d3-color@1 - 3", d3-color@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+d3-contour@4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-4.0.2.tgz#bb92063bc8c5663acb2422f99c73cbb6c6ae3bcc"
+  integrity sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==
+  dependencies:
+    d3-array "^3.2.0"
+
+d3-delaunay@6:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz#98169038733a0a5babbeda55054f795bb9e4a58b"
+  integrity sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==
+  dependencies:
+    delaunator "5"
+
+"d3-dispatch@1 - 3", d3-dispatch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
+
+"d3-drag@2 - 3", d3-drag@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
+  integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-selection "3"
+
+"d3-dsv@1 - 3", d3-dsv@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-3.0.1.tgz#c63af978f4d6a0d084a52a673922be2160789b73"
+  integrity sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
+  dependencies:
+    commander "7"
+    iconv-lite "0.6"
+    rw "1"
+
+"d3-ease@1 - 3", d3-ease@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+d3-fetch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-3.0.1.tgz#83141bff9856a0edb5e38de89cdcfe63d0a60a22"
+  integrity sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==
+  dependencies:
+    d3-dsv "1 - 3"
+
+d3-force@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
+  integrity sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-quadtree "1 - 3"
+    d3-timer "1 - 3"
+
+"d3-format@1 - 3", d3-format@3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.2.tgz#01fdb46b58beb1f55b10b42ad70b6e344d5eb2ae"
+  integrity sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==
+
+d3-geo@3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.1.tgz#6027cf51246f9b2ebd64f99e01dc7c3364033a4d"
+  integrity sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==
+  dependencies:
+    d3-array "2.5.0 - 3"
+
+d3-hierarchy@3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz#b01cd42c1eed3d46db77a5966cf726f8c09160c6"
+  integrity sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
+
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+d3-path@1:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+"d3-path@1 - 3", d3-path@3, d3-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
+  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
+
+d3-polygon@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-3.0.1.tgz#0b45d3dd1c48a29c8e057e6135693ec80bf16398"
+  integrity sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==
+
+"d3-quadtree@1 - 3", d3-quadtree@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
+  integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
+
+d3-random@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
+  integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
+
+d3-sankey@^0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/d3-sankey/-/d3-sankey-0.12.3.tgz#b3c268627bd72e5d80336e8de6acbfec9d15d01d"
+  integrity sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==
+  dependencies:
+    d3-array "1 - 2"
+    d3-shape "^1.2.0"
+
+d3-scale-chromatic@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#34c39da298b23c20e02f1a4b239bd0f22e7f1314"
+  integrity sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
+
+d3-scale@4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+"d3-selection@2 - 3", d3-selection@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
+
+d3-shape@3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.2.0.tgz#a1a839cbd9ba45f28674c69d7f855bcf91dfc6a5"
+  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
+  dependencies:
+    d3-path "^3.1.0"
+
+d3-shape@^1.2.0:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+  dependencies:
+    d3-path "1"
+
+"d3-time-format@2 - 4", d3-time-format@4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
+  integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
+  dependencies:
+    d3-array "2 - 3"
+
+"d3-timer@1 - 3", d3-timer@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
+
+"d3-transition@2 - 3", d3-transition@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
+  integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
+  dependencies:
+    d3-color "1 - 3"
+    d3-dispatch "1 - 3"
+    d3-ease "1 - 3"
+    d3-interpolate "1 - 3"
+    d3-timer "1 - 3"
+
+d3-zoom@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "2 - 3"
+    d3-transition "2 - 3"
+
+d3@^7.4.0, d3@^7.9.0:
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-7.9.0.tgz#579e7acb3d749caf8860bd1741ae8d371070cd5d"
+  integrity sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==
+  dependencies:
+    d3-array "3"
+    d3-axis "3"
+    d3-brush "3"
+    d3-chord "3"
+    d3-color "3"
+    d3-contour "4"
+    d3-delaunay "6"
+    d3-dispatch "3"
+    d3-drag "3"
+    d3-dsv "3"
+    d3-ease "3"
+    d3-fetch "3"
+    d3-force "3"
+    d3-format "3"
+    d3-geo "3"
+    d3-hierarchy "3"
+    d3-interpolate "3"
+    d3-path "3"
+    d3-polygon "3"
+    d3-quadtree "3"
+    d3-random "3"
+    d3-scale "4"
+    d3-scale-chromatic "3"
+    d3-selection "3"
+    d3-shape "3"
+    d3-time "3"
+    d3-time-format "4"
+    d3-timer "3"
+    d3-transition "3"
+    d3-zoom "3"
+
+dagre-d3-es@7.0.13:
+  version "7.0.13"
+  resolved "https://registry.yarnpkg.com/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz#acfb4b449f6dcdd48d8ea8081a6d8c59bc8128c3"
+  integrity sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==
+  dependencies:
+    d3 "^7.9.0"
+    lodash-es "^4.17.21"
+
+dayjs@^1.11.7:
+  version "1.11.21"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.21.tgz#57f87562e62de76f3c704bd2b8d522fc33068eb2"
+  integrity sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==
+
 debounce@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
@@ -3550,6 +3905,13 @@ del@^6.1.1:
     rimraf "^3.0.2"
     slash "^3.0.0"
 
+delaunator@5:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.1.0.tgz#d13271fbf3aff6753f9ea6e235557f20901046ea"
+  integrity sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==
+  dependencies:
+    robust-predicates "^3.0.2"
+
 depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -3597,6 +3959,11 @@ devlop@^1.0.0, devlop@^1.1.0:
   integrity sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
   dependencies:
     dequal "^2.0.0"
+
+diff@^5.0.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.2.tgz#0a4742797281d09cfa699b79ea32d27723623bad"
+  integrity sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -3656,6 +4023,13 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
+dompurify@^3.2.4:
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.10.tgz#96704295b4d8aeefcc8c7a90caa579b0ad69e46a"
+  integrity sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
+
 domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
@@ -3708,6 +4082,11 @@ electron-to-chromium@^1.4.601:
   version "1.4.620"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.620.tgz#a6481e0703f8df1e6821063fb43c9b818a7a2ef4"
   integrity sha512-a2fcSHOHrqBJsPNXtf6ZCEZpXrFCcbK1FBxfX3txoqWzNgtEDG1f3M59M98iwxhRW4iMKESnSjbJ310/rkrp0g==
+
+elkjs@^0.9.0:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/elkjs/-/elkjs-0.9.3.tgz#16711f8ceb09f1b12b99e971b138a8384a529161"
+  integrity sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -4701,6 +5080,13 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@0.6:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 icss-utils@^5.0.0, icss-utils@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
@@ -4788,6 +5174,16 @@ inline-style-parser@0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.2.2.tgz#d498b4e6de0373458fc610ff793f6b14ebf45633"
   integrity sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ==
+
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
+
+internmap@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
+  integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
 
 interpret@^1.0.0:
   version "1.4.0"
@@ -5117,12 +5513,24 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+katex@^0.16.9:
+  version "0.16.47"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.16.47.tgz#0a13a42c2deb4f74e61f162d440b9165a548030f"
+  integrity sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==
+  dependencies:
+    commander "^8.3.0"
+
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
   integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
   dependencies:
     json-buffer "3.0.1"
+
+khroma@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/khroma/-/khroma-2.1.0.tgz#45f2ce94ce231a437cf5b63c2e886e6eb42bbbb1"
+  integrity sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==
 
 kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.3"
@@ -5133,6 +5541,11 @@ kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
+kleur@^4.0.3:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
+  integrity sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
 
 latest-version@^7.0.0:
   version "7.0.0"
@@ -5148,6 +5561,11 @@ launch-editor@^2.6.0:
   dependencies:
     picocolors "^1.0.0"
     shell-quote "^1.8.1"
+
+layout-base@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-1.0.2.tgz#1291e296883c322a9dd4c5dd82063721b53e26e2"
+  integrity sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==
 
 leven@^3.1.0:
   version "3.1.0"
@@ -5204,6 +5622,11 @@ locate-path@^7.1.0:
   integrity sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==
   dependencies:
     p-locate "^6.0.0"
+
+lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -5296,6 +5719,24 @@ mdast-util-find-and-replace@^3.0.0, mdast-util-find-and-replace@^3.0.1:
     escape-string-regexp "^5.0.0"
     unist-util-is "^6.0.0"
     unist-util-visit-parents "^6.0.0"
+
+mdast-util-from-markdown@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz#9421a5a247f10d31d2faed2a30df5ec89ceafcf0"
+  integrity sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    decode-named-character-reference "^1.0.0"
+    mdast-util-to-string "^3.1.0"
+    micromark "^3.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-decode-string "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    unist-util-stringify-position "^3.0.0"
+    uvu "^0.5.0"
 
 mdast-util-from-markdown@^2.0.0:
   version "2.0.0"
@@ -5482,6 +5923,13 @@ mdast-util-to-markdown@^2.0.0:
     unist-util-visit "^5.0.0"
     zwitch "^2.0.0"
 
+mdast-util-to-string@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz#66f7bb6324756741c5f47a53557f0cbf16b6f789"
+  integrity sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+
 mdast-util-to-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz#7a5121475556a04e7eddeb67b264aae79d312814"
@@ -5521,10 +5969,58 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
+mermaid@^10.4.0:
+  version "10.9.6"
+  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-10.9.6.tgz#75e683737b20adaff034e61ee1974dfd1a70c379"
+  integrity sha512-XRjjRaI4aPCAMpVaOhxIwLYdx3U4Cb6mN0M268ggFAfFRqsvyFW8zxWbEZazN/mPkqsVWThb0oa1UawWK+XMNg==
+  dependencies:
+    "@braintree/sanitize-url" "^6.0.1"
+    "@types/d3-scale" "^4.0.3"
+    "@types/d3-scale-chromatic" "^3.0.0"
+    cytoscape "^3.28.1"
+    cytoscape-cose-bilkent "^4.1.0"
+    d3 "^7.4.0"
+    d3-sankey "^0.12.3"
+    dagre-d3-es "7.0.13"
+    dayjs "^1.11.7"
+    dompurify "^3.2.4"
+    elkjs "^0.9.0"
+    katex "^0.16.9"
+    khroma "^2.0.0"
+    lodash-es "^4.17.21"
+    mdast-util-from-markdown "^1.3.0"
+    non-layered-tidy-tree-layout "^2.0.2"
+    stylis "^4.1.3"
+    ts-dedent "^2.2.0"
+    uuid "^9.0.0 || ^10 || ^11.1.0 || ^12 || ^13 || ^14.0.0"
+    web-worker "^1.2.0"
+
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
+
+micromark-core-commonmark@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz#1386628df59946b2d39fb2edfd10f3e8e0a75bb8"
+  integrity sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-factory-destination "^1.0.0"
+    micromark-factory-label "^1.0.0"
+    micromark-factory-space "^1.0.0"
+    micromark-factory-title "^1.0.0"
+    micromark-factory-whitespace "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-chunked "^1.0.0"
+    micromark-util-classify-character "^1.0.0"
+    micromark-util-html-tag-name "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-resolve-all "^1.0.0"
+    micromark-util-subtokenize "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.1"
+    uvu "^0.5.0"
 
 micromark-core-commonmark@^2.0.0:
   version "2.0.0"
@@ -5716,6 +6212,15 @@ micromark-extension-mdxjs@^3.0.0:
     micromark-util-combine-extensions "^2.0.0"
     micromark-util-types "^2.0.0"
 
+micromark-factory-destination@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz#eb815957d83e6d44479b3df640f010edad667b9f"
+  integrity sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
 micromark-factory-destination@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz#857c94debd2c873cba34e0445ab26b74f6a6ec07"
@@ -5724,6 +6229,16 @@ micromark-factory-destination@^2.0.0:
     micromark-util-character "^2.0.0"
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
+
+micromark-factory-label@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz#cc95d5478269085cfa2a7282b3de26eb2e2dec68"
+  integrity sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
 
 micromark-factory-label@^2.0.0:
   version "2.0.0"
@@ -5765,6 +6280,16 @@ micromark-factory-space@^2.0.0:
     micromark-util-character "^2.0.0"
     micromark-util-types "^2.0.0"
 
+micromark-factory-title@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz#dd0fe951d7a0ac71bdc5ee13e5d1465ad7f50ea1"
+  integrity sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
 micromark-factory-title@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz#726140fc77892af524705d689e1cf06c8a83ea95"
@@ -5774,6 +6299,16 @@ micromark-factory-title@^2.0.0:
     micromark-util-character "^2.0.0"
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
+
+micromark-factory-whitespace@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz#798fb7489f4c8abafa7ca77eed6b5745853c9705"
+  integrity sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
 
 micromark-factory-whitespace@^2.0.0:
   version "2.0.0"
@@ -5801,12 +6336,28 @@ micromark-util-character@^2.0.0:
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
 
+micromark-util-chunked@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz#37a24d33333c8c69a74ba12a14651fd9ea8a368b"
+  integrity sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
 micromark-util-chunked@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz#e51f4db85fb203a79dbfef23fd41b2f03dc2ef89"
   integrity sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==
   dependencies:
     micromark-util-symbol "^2.0.0"
+
+micromark-util-classify-character@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz#6a7f8c8838e8a120c8e3c4f2ae97a2bff9190e9d"
+  integrity sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
 
 micromark-util-classify-character@^2.0.0:
   version "2.0.0"
@@ -5817,6 +6368,14 @@ micromark-util-classify-character@^2.0.0:
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
 
+micromark-util-combine-extensions@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz#192e2b3d6567660a85f735e54d8ea6e3952dbe84"
+  integrity sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==
+  dependencies:
+    micromark-util-chunked "^1.0.0"
+    micromark-util-types "^1.0.0"
+
 micromark-util-combine-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz#75d6ab65c58b7403616db8d6b31315013bfb7ee5"
@@ -5825,12 +6384,29 @@ micromark-util-combine-extensions@^2.0.0:
     micromark-util-chunked "^2.0.0"
     micromark-util-types "^2.0.0"
 
+micromark-util-decode-numeric-character-reference@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz#b1e6e17009b1f20bc652a521309c5f22c85eb1c6"
+  integrity sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
 micromark-util-decode-numeric-character-reference@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz#2698bbb38f2a9ba6310e359f99fcb2b35a0d2bd5"
   integrity sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==
   dependencies:
     micromark-util-symbol "^2.0.0"
+
+micromark-util-decode-string@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz#dc12b078cba7a3ff690d0203f95b5d5537f2809c"
+  integrity sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-symbol "^1.0.0"
 
 micromark-util-decode-string@^2.0.0:
   version "2.0.0"
@@ -5841,6 +6417,11 @@ micromark-util-decode-string@^2.0.0:
     micromark-util-character "^2.0.0"
     micromark-util-decode-numeric-character-reference "^2.0.0"
     micromark-util-symbol "^2.0.0"
+
+micromark-util-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz#92e4f565fd4ccb19e0dcae1afab9a173bbeb19a5"
+  integrity sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==
 
 micromark-util-encode@^2.0.0:
   version "2.0.0"
@@ -5861,10 +6442,22 @@ micromark-util-events-to-acorn@^2.0.0:
     micromark-util-types "^2.0.0"
     vfile-message "^4.0.0"
 
+micromark-util-html-tag-name@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz#48fd7a25826f29d2f71479d3b4e83e94829b3588"
+  integrity sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==
+
 micromark-util-html-tag-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz#ae34b01cbe063363847670284c6255bb12138ec4"
   integrity sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==
+
+micromark-util-normalize-identifier@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz#7a73f824eb9f10d442b4d7f120fecb9b38ebf8b7"
+  integrity sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
 
 micromark-util-normalize-identifier@^2.0.0:
   version "2.0.0"
@@ -5873,12 +6466,28 @@ micromark-util-normalize-identifier@^2.0.0:
   dependencies:
     micromark-util-symbol "^2.0.0"
 
+micromark-util-resolve-all@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz#4652a591ee8c8fa06714c9b54cd6c8e693671188"
+  integrity sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==
+  dependencies:
+    micromark-util-types "^1.0.0"
+
 micromark-util-resolve-all@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz#189656e7e1a53d0c86a38a652b284a252389f364"
   integrity sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==
   dependencies:
     micromark-util-types "^2.0.0"
+
+micromark-util-sanitize-uri@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz#613f738e4400c6eedbc53590c67b197e30d7f90d"
+  integrity sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-encode "^1.0.0"
+    micromark-util-symbol "^1.0.0"
 
 micromark-util-sanitize-uri@^2.0.0:
   version "2.0.0"
@@ -5888,6 +6497,16 @@ micromark-util-sanitize-uri@^2.0.0:
     micromark-util-character "^2.0.0"
     micromark-util-encode "^2.0.0"
     micromark-util-symbol "^2.0.0"
+
+micromark-util-subtokenize@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz#941c74f93a93eaf687b9054aeb94642b0e92edb1"
+  integrity sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==
+  dependencies:
+    micromark-util-chunked "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
 
 micromark-util-subtokenize@^2.0.0:
   version "2.0.0"
@@ -5909,7 +6528,7 @@ micromark-util-symbol@^2.0.0:
   resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz#12225c8f95edf8b17254e47080ce0862d5db8044"
   integrity sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==
 
-micromark-util-types@^1.0.0:
+micromark-util-types@^1.0.0, micromark-util-types@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-1.1.0.tgz#e6676a8cae0bb86a2171c498167971886cb7e283"
   integrity sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==
@@ -5918,6 +6537,29 @@ micromark-util-types@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-2.0.0.tgz#63b4b7ffeb35d3ecf50d1ca20e68fc7caa36d95e"
   integrity sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==
+
+micromark@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-3.2.0.tgz#1af9fef3f995ea1ea4ac9c7e2f19c48fd5c006e9"
+  integrity sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==
+  dependencies:
+    "@types/debug" "^4.0.0"
+    debug "^4.0.0"
+    decode-named-character-reference "^1.0.0"
+    micromark-core-commonmark "^1.0.1"
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-chunked "^1.0.0"
+    micromark-util-combine-extensions "^1.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-encode "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-resolve-all "^1.0.0"
+    micromark-util-sanitize-uri "^1.0.0"
+    micromark-util-subtokenize "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.1"
+    uvu "^0.5.0"
 
 micromark@^4.0.0:
   version "4.0.0"
@@ -6018,6 +6660,11 @@ minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+mri@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
+  integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
+
 mrmime@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-2.0.0.tgz#151082a6e06e59a9a39b46b3e14d5cfe92b3abb4"
@@ -6088,6 +6735,11 @@ node-releases@^2.0.14:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
   integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
+
+non-layered-tidy-tree-layout@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz#57d35d13c356643fc296a55fb11ac15e74da7804"
+  integrity sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -7287,6 +7939,11 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+robust-predicates@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.3.tgz#1099061b3349e2c5abec6c2ab0acd440d24d4062"
+  integrity sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==
+
 rtl-detect@^1.0.4:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/rtl-detect/-/rtl-detect-1.1.2.tgz#ca7f0330af5c6bb626c15675c642ba85ad6273c6"
@@ -7309,6 +7966,18 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
+
+sade@^1.7.3:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
+  integrity sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==
+  dependencies:
+    mri "^1.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -7319,7 +7988,7 @@ safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -7785,6 +8454,11 @@ stylehacks@^5.1.1:
     browserslist "^4.21.4"
     postcss-selector-parser "^6.0.4"
 
+stylis@^4.1.3:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.4.0.tgz#c5846c9345f4bfc51bd0cbd7ca35a0744f485a5d"
+  integrity sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -7912,6 +8586,11 @@ trough@^2.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-2.1.0.tgz#0f7b511a4fde65a46f18477ab38849b22c554876"
   integrity sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==
 
+ts-dedent@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.3.0.tgz#8fac36c7902b541c154ac13a27ac467997af11f8"
+  integrity sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==
+
 tslib@^2.0.3, tslib@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
@@ -8029,6 +8708,13 @@ unist-util-remove-position@^5.0.0:
     "@types/unist" "^3.0.0"
     unist-util-visit "^5.0.0"
 
+unist-util-stringify-position@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz#03ad3348210c2d930772d64b489580c13a7db39d"
+  integrity sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
 unist-util-stringify-position@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz#449c6e21a880e0855bf5aabadeb3a740314abac2"
@@ -8132,6 +8818,21 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+"uuid@^9.0.0 || ^10 || ^11.1.0 || ^12 || ^13 || ^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
+
+uvu@^0.5.0:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/uvu/-/uvu-0.5.6.tgz#2754ca20bcb0bb59b64e9985e84d2e81058502df"
+  integrity sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==
+  dependencies:
+    dequal "^2.0.0"
+    diff "^5.0.0"
+    kleur "^4.0.3"
+    sade "^1.7.3"
+
 value-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
@@ -8186,6 +8887,11 @@ web-namespaces@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
+
+web-worker@^1.2.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/web-worker/-/web-worker-1.5.0.tgz#71b2b0fbcc4293e8f0aa4f6b8a3ffebff733dcc5"
+  integrity sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==
 
 webpack-bundle-analyzer@^4.9.0:
   version "4.10.1"


### PR DESCRIPTION
## Summary

- Adds the CNTUG design system (CNCF brand palette, Clarity City + Noto Sans TC + JetBrains Mono, dark mode per Apple HIG) as portable token + Infima-bridge files.
- Mirrors the implementation already shipping on `docs.cloudnative.tw` (Infra Labs), so the two sites share one source of truth.
- Fixes hero CTA buttons that were touching each other by adding `gap` + `flex-wrap` to the `.buttons` containers.

## Files

- `src/css/cntug-tokens.css` — design tokens (portable).
- `src/css/cntug-infima.css` — maps tokens onto Infima `--ifm-*` variables (Docusaurus-only).
- `src/css/README.md` — design system docs.
- `src/css/custom.css` — now imports the two files; keeps the site-specific `.button--sponsor` CNCF-Pink override.
- `src/pages/index.module.css`, `src/components/HomepageFeatures/styles.module.css` — `gap` + `flex-wrap` on `.buttons`.

## Test plan

- [ ] `yarn build` succeeds
- [ ] Navbar, sidebar, footer, code blocks, and admonitions render in CNCF Blue
- [ ] Dark mode flips to layered grays with desaturated brand blue
- [ ] Hero CTA buttons have visible spacing and wrap on narrow viewports
- [ ] `.button--sponsor` still renders in CNCF Pink on the homepage